### PR TITLE
php version switch bug in restarting php services

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -189,8 +189,8 @@ class Brew
             if ($this->installed($service)) {
                 info('[' . $service . '] Restarting');
 
-                $this->cli->quietly('sudo brew services stop ' . $service);
-                $this->cli->quietly('sudo brew services start ' . $service);
+                $this->cli->quietlyAsUser('brew services stop ' . $service);
+                $this->cli->quietlyAsUser('brew services start ' . $service);
             }
         }
     }
@@ -208,7 +208,7 @@ class Brew
             if ($this->installed($service)) {
                 info('[' . $service . '] Stopping');
 
-                $this->cli->quietly('sudo brew services stop ' . $service);
+                $this->cli->quietlyAsUser('brew services stop ' . $service);
             }
         }
     }


### PR DESCRIPTION
Valet uses the sudo command to restart the php services after switching a php version. This caused the valet use command to be not switch my php version.
By chaning the restart commando to use 'sudo -u user()' the current user is used to restart the brew services. This is the same when restarting brew services manually (which worked flawlessly).